### PR TITLE
feat: add getNonUniqueCustomLabels utility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export * from './util/getImplicitHydrogensCount.js';
 export * from './util/getMF.js';
 export * from './util/getCharge.js';
 export * from './util/getMolfilesMapping.js';
+export * from './util/getNonUniqueCustomLabels.js';
 export * from './util/getNMRHints.js';
 export * from './util/getNextNMRHint.js';
 export * from './util/getProperties.js';

--- a/src/util/__tests__/getNonUniqueCustomLabels.test.ts
+++ b/src/util/__tests__/getNonUniqueCustomLabels.test.ts
@@ -1,0 +1,41 @@
+import { Molecule } from 'openchemlib';
+import { expect, test } from 'vitest';
+
+import { applyFragmentLabels } from '../applyFragmentLabels.ts';
+import { getNonUniqueCustomLabels } from '../getNonUniqueCustomLabels.ts';
+
+test('no custom labels returns an empty array', () => {
+  const molecule = Molecule.fromSmiles('CCC(=O)CC');
+
+  expect(getNonUniqueCustomLabels(molecule)).toStrictEqual([]);
+});
+
+test('all unique custom labels returns an empty array', () => {
+  const molecule = Molecule.fromSmiles('CCO');
+  molecule.setAtomCustomLabel(0, 'a');
+  molecule.setAtomCustomLabel(1, 'b');
+  molecule.setAtomCustomLabel(2, 'c');
+
+  expect(getNonUniqueCustomLabels(molecule)).toStrictEqual([]);
+});
+
+test('only the duplicated labels are reported', () => {
+  const molecule = Molecule.fromSmiles('CCCCO');
+  molecule.setAtomCustomLabel(0, 'dup');
+  molecule.setAtomCustomLabel(1, 'unique');
+  molecule.setAtomCustomLabel(2, 'dup');
+
+  expect(getNonUniqueCustomLabels(molecule)).toStrictEqual(['dup']);
+});
+
+test('non-unique labels created by applyFragmentLabels', () => {
+  const molecule = Molecule.fromSmiles('CCC(=O)CCCCCCC(=O)CC');
+  const fragment = Molecule.fromSmiles('CCC(=O)');
+  fragment.setAtomCustomLabel(0, 'β');
+  fragment.setAtomCustomLabel(1, 'ɑ');
+  fragment.setFragment(true);
+
+  applyFragmentLabels(molecule, fragment);
+
+  expect(getNonUniqueCustomLabels(molecule)).toStrictEqual(['β', 'ɑ']);
+});

--- a/src/util/getNonUniqueCustomLabels.ts
+++ b/src/util/getNonUniqueCustomLabels.ts
@@ -1,0 +1,24 @@
+import type { Molecule } from 'openchemlib';
+
+/**
+ * Returns the custom labels that are shared by more than one atom.
+ * Atoms without a custom label are ignored, so a molecule with no custom labels,
+ * or with only unique ones, yields an empty array.
+ * @param molecule - The molecule whose atom custom labels should be checked.
+ * @returns The deduplicated list of non-unique custom labels, in first-seen
+ * order. Empty when every custom label is unique.
+ */
+export function getNonUniqueCustomLabels(molecule: Molecule): string[] {
+  const counts = new Map<string, number>();
+  for (let i = 0; i < molecule.getAllAtoms(); i++) {
+    const customLabel = molecule.getAtomCustomLabel(i)?.replace(/^\]/, '');
+    if (!customLabel) continue;
+    counts.set(customLabel, (counts.get(customLabel) ?? 0) + 1);
+  }
+
+  const nonUniqueCustomLabels = [];
+  for (const [customLabel, count] of counts) {
+    if (count > 1) nonUniqueCustomLabels.push(customLabel);
+  }
+  return nonUniqueCustomLabels;
+}


### PR DESCRIPTION
Adds `getNonUniqueCustomLabels(molecule)`, a general utility (not tied to `TopicMolecule`) that returns the custom labels shared by more than one atom. Returns an empty array when every custom label is unique or none are set. Useful to verify that labels applied via `applyFragmentLabels` / `setAtomCustomLabel` are unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)